### PR TITLE
join without any char

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -100,7 +100,7 @@ function executeSql(sql, args, cb) {
                 var result = {},
                     json;
                 try {
-                    result = JSON.parse(data.join("."));
+                    result = JSON.parse(data.join(''));
                 } catch (ex) {
                     cb(ex, null, null);
                     return;


### PR DESCRIPTION
join with a dot produces extra comma and destroys valid json