### PR TITLE
fix typo

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -231,7 +231,7 @@ module.exports = {
   /**
    * @param {string} tableName
    * @param {string[]} options
-   * @param {string} whereClaus
+   * @param {string} whereClause
    * @param {requestCallback} cb
    */
   update: dCap(function update (tableName, options, whereClause, cb) {


### PR DESCRIPTION
fix typoe in comment for `update` method: `whereClaus` to `whereClause`