### PR TITLE
add the Content-Type to the Header to prevent deprecation warning.

### DIFF
--- a/lib/connection-pool.js
+++ b/lib/connection-pool.js
@@ -66,7 +66,8 @@ module.exports = {
           path: '/_sql?types',
           method: 'POST',
           headers: {
-            'Connection': 'keep-alive'
+            'Connection': 'keep-alive',
+            'Content-Type': 'application/json'
           }
         },
         protocol: e.protocol

--- a/lib/connection-pool.js
+++ b/lib/connection-pool.js
@@ -67,7 +67,8 @@ module.exports = {
           method: 'POST',
           headers: {
             'Connection': 'keep-alive',
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
           }
         },
         protocol: e.protocol


### PR DESCRIPTION
Crate DB has deprecated content type detection for rest requests in v2.2. This PR is to prevent the deprecation Warning.

`[WARN ][o.e.d.r.RestController   ] Content type detection for rest requests is deprecated. Specify the content type using the [Content-Type] header.`