### PR TITLE
catch 'error' event on request in case of ECONNREFUSED

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -121,6 +121,13 @@ function _executeSql (sql, args = [], bulk = false) {
     }
 
     const req = connectionPool.getSqlRequest(callback)
+    // let node know what to do in case of unexpected errors
+    // before anything has been sent/received.
+    req.on('error', (err) => {
+      console.log("Unexpected connection error", err)
+      req.end()
+      return reject(err)
+    })
     let command = {
       stmt: sql
     }


### PR DESCRIPTION
Hi,

When used with node-red-contrib-crate, node-red crashes when the database is unavailable. 
The cause is an unexpected socket hangup because error events on the request are not handled.
This commit rejects the promise, and calls 'req.end()' to prevent an unexpected socket hangup.

Regards,

Gert